### PR TITLE
FTB Quests - EMI integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,13 @@ allprojects {
         }
 
         maven {
+            url "https://maven.terraformersmc.com/"
+            content {
+                includeGroup "dev.emi"
+            }
+        }
+
+        maven {
             url "https://www.cursemaven.com"
             content {
                 includeGroup "curse.maven"

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 
     modCompileOnly("me.shedaniel:RoughlyEnoughItems-api:${rootProject.rei_version}")
     modCompileOnly("mezz.jei:jei-${rootProject.minecraft_version}-common-api:${rootProject.jei_version}")
+    modCompileOnly("dev.emi:emi-xplat-intermediary:${rootProject.emi_version}+${rootProject.minecraft_version}:api")
 
     compileOnly("net.luckperms:api:${rootProject.luckperms_api_version}")
 

--- a/common/src/main/java/dev/ftb/mods/ftbxmodcompat/FTBXModCompat.java
+++ b/common/src/main/java/dev/ftb/mods/ftbxmodcompat/FTBXModCompat.java
@@ -21,6 +21,7 @@ public class FTBXModCompat {
     public static boolean isGameStagesLoaded;
     public static boolean isREILoaded;
     public static boolean isJEILoaded;
+    public static boolean isEMILoaded;
     public static boolean isLuckPermsLoaded;
     public static boolean isWaystonesLoaded;
     public static boolean isCommonProtLoaded;
@@ -47,6 +48,7 @@ public class FTBXModCompat {
         isGameStagesLoaded = Platform.isModLoaded("gamestages");
         isREILoaded = Platform.isModLoaded("roughlyenoughitems");
         isJEILoaded = Platform.isModLoaded("jei");
+        isEMILoaded = Platform.isModLoaded("emi");
         isLuckPermsLoaded = Platform.isModLoaded("luckperms");
         isWaystonesLoaded = Platform.isModLoaded("waystones");
         isCommonProtLoaded = Platform.isModLoaded("common-protection-api");

--- a/common/src/main/java/dev/ftb/mods/ftbxmodcompat/ftbquests/FTBQuestsSetup.java
+++ b/common/src/main/java/dev/ftb/mods/ftbxmodcompat/ftbquests/FTBQuestsSetup.java
@@ -2,12 +2,15 @@ package dev.ftb.mods.ftbxmodcompat.ftbquests;
 
 import dev.ftb.mods.ftbquests.FTBQuests;
 import dev.ftb.mods.ftbxmodcompat.FTBXModCompat;
+import dev.ftb.mods.ftbxmodcompat.ftbquests.emi.helper.EMIRecipeHelper;
 import dev.ftb.mods.ftbxmodcompat.ftbquests.jei.helper.JEIRecipeHelper;
 import dev.ftb.mods.ftbxmodcompat.ftbquests.rei.helper.REIRecipeHelper;
 
 public class FTBQuestsSetup {
     public static void init() {
-        if (FTBXModCompat.isJEILoaded) {
+        if (FTBXModCompat.isEMILoaded) {
+            FTBQuests.setRecipeModHelper(new EMIRecipeHelper());
+        } else if (FTBXModCompat.isJEILoaded) {
             FTBQuests.setRecipeModHelper(new JEIRecipeHelper());
         } else if (FTBXModCompat.isREILoaded) {
             FTBQuests.setRecipeModHelper(new REIRecipeHelper());

--- a/common/src/main/java/dev/ftb/mods/ftbxmodcompat/ftbquests/FTBQuestsSetup.java
+++ b/common/src/main/java/dev/ftb/mods/ftbxmodcompat/ftbquests/FTBQuestsSetup.java
@@ -8,12 +8,15 @@ import dev.ftb.mods.ftbxmodcompat.ftbquests.rei.helper.REIRecipeHelper;
 
 public class FTBQuestsSetup {
     public static void init() {
+        // EMI will load JEI plugins if JEI is also installed,
+        // and REI will do the same if "REI Plugin Compatibilities" is installed,
+        // so we make sure to check for JEI *last*
         if (FTBXModCompat.isEMILoaded) {
             FTBQuests.setRecipeModHelper(new EMIRecipeHelper());
-        } else if (FTBXModCompat.isJEILoaded) {
-            FTBQuests.setRecipeModHelper(new JEIRecipeHelper());
         } else if (FTBXModCompat.isREILoaded) {
             FTBQuests.setRecipeModHelper(new REIRecipeHelper());
+        } else if (FTBXModCompat.isJEILoaded) {
+            FTBQuests.setRecipeModHelper(new JEIRecipeHelper());
         }
         FTBXModCompat.LOGGER.info("[FTB Quests] recipe helper provider is [{}]", FTBQuests.getRecipeModHelper().getHelperName());
     }

--- a/common/src/main/java/dev/ftb/mods/ftbxmodcompat/ftbquests/emi/EMICategories.java
+++ b/common/src/main/java/dev/ftb/mods/ftbxmodcompat/ftbquests/emi/EMICategories.java
@@ -1,0 +1,12 @@
+package dev.ftb.mods.ftbxmodcompat.ftbquests.emi;
+
+import dev.emi.emi.api.recipe.EmiRecipeCategory;
+import dev.emi.emi.api.stack.EmiStack;
+import dev.ftb.mods.ftbquests.FTBQuests;
+import dev.ftb.mods.ftbquests.item.FTBQuestsItems;
+import net.minecraft.resources.ResourceLocation;
+
+public class EMICategories {
+    public static final EmiRecipeCategory QUEST = new EmiRecipeCategory(ResourceLocation.tryBuild(FTBQuests.MOD_ID, "quest"), EmiStack.of(FTBQuestsItems.BOOK.get()));
+    public static final EmiRecipeCategory LOOT_CRATE = new EmiRecipeCategory(ResourceLocation.tryBuild(FTBQuests.MOD_ID, "loot_crate"), EmiStack.of(FTBQuestsItems.BOOK.get()));
+}

--- a/common/src/main/java/dev/ftb/mods/ftbxmodcompat/ftbquests/emi/FTBQuestsEMIIntegration.java
+++ b/common/src/main/java/dev/ftb/mods/ftbxmodcompat/ftbquests/emi/FTBQuestsEMIIntegration.java
@@ -1,0 +1,20 @@
+package dev.ftb.mods.ftbxmodcompat.ftbquests.emi;
+
+import dev.emi.emi.api.EmiApi;
+import dev.emi.emi.api.EmiEntrypoint;
+import dev.emi.emi.api.EmiPlugin;
+import dev.emi.emi.api.EmiRegistry;
+import dev.emi.emi.api.stack.EmiStack;
+import net.minecraft.world.item.ItemStack;
+
+@EmiEntrypoint
+public class FTBQuestsEMIIntegration implements EmiPlugin {
+    @Override
+    public void register(EmiRegistry registry) {
+        // TODO
+    }
+
+    public static void showRecipes(ItemStack stack) {
+        EmiApi.displayRecipes(EmiStack.of(stack));
+    }
+}

--- a/common/src/main/java/dev/ftb/mods/ftbxmodcompat/ftbquests/emi/FTBQuestsEMIIntegration.java
+++ b/common/src/main/java/dev/ftb/mods/ftbxmodcompat/ftbquests/emi/FTBQuestsEMIIntegration.java
@@ -5,13 +5,24 @@ import dev.emi.emi.api.EmiEntrypoint;
 import dev.emi.emi.api.EmiPlugin;
 import dev.emi.emi.api.EmiRegistry;
 import dev.emi.emi.api.stack.EmiStack;
+import dev.ftb.mods.ftbquests.item.FTBQuestsItems;
+import dev.ftb.mods.ftbxmodcompat.FTBXModCompat;
 import net.minecraft.world.item.ItemStack;
 
 @EmiEntrypoint
 public class FTBQuestsEMIIntegration implements EmiPlugin {
+    public static final EmiStack WORKSTATION = EmiStack.of(FTBQuestsItems.BOOK.get());
+
     @Override
     public void register(EmiRegistry registry) {
-        // TODO
+        if (FTBXModCompat.isFTBQuestsLoaded) {
+            registry.addCategory(EMICategories.QUEST);
+            registry.addWorkstation(EMICategories.QUEST, WORKSTATION);
+
+            QuestRecipeManager.INSTANCE.getQuests().forEach(quest -> {
+                registry.addRecipe(new QuestRecipe(quest));
+            });
+        }
     }
 
     public static void showRecipes(ItemStack stack) {

--- a/common/src/main/java/dev/ftb/mods/ftbxmodcompat/ftbquests/emi/LootCrateRecipe.java
+++ b/common/src/main/java/dev/ftb/mods/ftbxmodcompat/ftbquests/emi/LootCrateRecipe.java
@@ -1,0 +1,4 @@
+package dev.ftb.mods.ftbxmodcompat.ftbquests.emi;
+
+public class LootCrateRecipe {
+}

--- a/common/src/main/java/dev/ftb/mods/ftbxmodcompat/ftbquests/emi/QuestRecipe.java
+++ b/common/src/main/java/dev/ftb/mods/ftbxmodcompat/ftbquests/emi/QuestRecipe.java
@@ -1,0 +1,64 @@
+package dev.ftb.mods.ftbxmodcompat.ftbquests.emi;
+
+import dev.emi.emi.api.recipe.BasicEmiRecipe;
+import dev.emi.emi.api.render.EmiTexture;
+import dev.emi.emi.api.stack.EmiIngredient;
+import dev.emi.emi.api.stack.EmiStack;
+import dev.emi.emi.api.widget.WidgetHolder;
+import dev.ftb.mods.ftbquests.FTBQuests;
+import dev.ftb.mods.ftbxmodcompat.ftbquests.emi.widget.ClickableTextWidget;
+import dev.ftb.mods.ftbxmodcompat.ftbquests.recipemod_common.WrappedQuest;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
+
+public class QuestRecipe extends BasicEmiRecipe {
+    private final WrappedQuest wrappedQuest;
+
+    public QuestRecipe(WrappedQuest wrappedQuest) {
+        super(EMICategories.QUEST, ResourceLocation.tryBuild(FTBQuests.MOD_ID, String.valueOf(wrappedQuest.quest.id)), 152, 70);
+
+        for (Ingredient ingredient : wrappedQuest.inputIngredients()) {
+            this.inputs.add(EmiIngredient.of(ingredient));
+        }
+
+        for (Ingredient ingredient : wrappedQuest.outputIngredients()) {
+            for (ItemStack item : ingredient.getItems()) {
+                this.outputs.add(EmiStack.of(item));
+            }
+        }
+
+        this.wrappedQuest = wrappedQuest;
+    }
+
+    @Override
+    public void addWidgets(WidgetHolder widgets) {
+        int inputSize = Math.min(9, inputs.size());
+        for (int i = 0; i < 9; i++) {
+            EmiIngredient ingredient = i < inputSize ? inputs.get(i) : EmiStack.EMPTY;
+            widgets.addSlot(ingredient, (i % 3) * 18 + 4, (i / 3) * 18 + 13);
+        }
+
+        int outputSize = Math.min(9, outputs.size());
+        for (int i = 0; i < 9; i++) {
+            EmiIngredient ingredient = i < outputSize ? outputs.get(i) : EmiStack.EMPTY;
+            widgets.addSlot(ingredient, (i % 3) * 18 + 94, (i / 3) * 18 + 13).recipeContext(this);
+        }
+
+        widgets.addTexture(EmiTexture.EMPTY_ARROW, 64, 32);
+
+        Component text = wrappedQuest.quest.getTitle().copy().withStyle(ChatFormatting.UNDERLINE);
+        widgets.add(new ClickableTextWidget(text.getVisualOrderText(), 1, 1, 0, false, c -> {
+            Minecraft.getInstance().setScreen(null);
+            wrappedQuest.openQuestGui();
+        }));
+    }
+
+    @Override
+    public boolean supportsRecipeTree() {
+        return false;
+    }
+}

--- a/common/src/main/java/dev/ftb/mods/ftbxmodcompat/ftbquests/emi/QuestRecipeManager.java
+++ b/common/src/main/java/dev/ftb/mods/ftbxmodcompat/ftbquests/emi/QuestRecipeManager.java
@@ -1,0 +1,20 @@
+package dev.ftb.mods.ftbxmodcompat.ftbquests.emi;
+
+import dev.ftb.mods.ftbxmodcompat.ftbquests.recipemod_common.WrappedQuest;
+import dev.ftb.mods.ftbxmodcompat.ftbquests.recipemod_common.WrappedQuestCache;
+
+import java.util.List;
+
+public enum QuestRecipeManager {
+    INSTANCE;
+
+    private final WrappedQuestCache cache = new WrappedQuestCache();
+
+    public void refresh() {
+        cache.clear();
+    }
+
+    public List<WrappedQuest> getQuests() {
+        return cache.getCachedItems();
+    }
+}

--- a/common/src/main/java/dev/ftb/mods/ftbxmodcompat/ftbquests/emi/helper/EMIRecipeHelper.java
+++ b/common/src/main/java/dev/ftb/mods/ftbxmodcompat/ftbquests/emi/helper/EMIRecipeHelper.java
@@ -1,6 +1,7 @@
 package dev.ftb.mods.ftbxmodcompat.ftbquests.emi.helper;
 
 import dev.ftb.mods.ftbxmodcompat.ftbquests.emi.FTBQuestsEMIIntegration;
+import dev.ftb.mods.ftbxmodcompat.ftbquests.emi.QuestRecipeManager;
 import dev.ftb.mods.ftbxmodcompat.ftbquests.recipemod_common.BaseRecipeHelper;
 import net.minecraft.world.item.ItemStack;
 
@@ -16,7 +17,7 @@ public class EMIRecipeHelper extends BaseRecipeHelper {
     }
 
     protected void refreshQuests() {
-        // TODO
+        QuestRecipeManager.INSTANCE.refresh();
     }
 
     protected void refreshLootcrates() {

--- a/common/src/main/java/dev/ftb/mods/ftbxmodcompat/ftbquests/emi/helper/EMIRecipeHelper.java
+++ b/common/src/main/java/dev/ftb/mods/ftbxmodcompat/ftbquests/emi/helper/EMIRecipeHelper.java
@@ -1,0 +1,25 @@
+package dev.ftb.mods.ftbxmodcompat.ftbquests.emi.helper;
+
+import dev.ftb.mods.ftbxmodcompat.ftbquests.emi.FTBQuestsEMIIntegration;
+import dev.ftb.mods.ftbxmodcompat.ftbquests.recipemod_common.BaseRecipeHelper;
+import net.minecraft.world.item.ItemStack;
+
+public class EMIRecipeHelper extends BaseRecipeHelper {
+    @Override
+    public void showRecipes(ItemStack itemStack) {
+        FTBQuestsEMIIntegration.showRecipes(itemStack);
+    }
+
+    @Override
+    public String getHelperName() {
+        return "EMI";
+    }
+
+    protected void refreshQuests() {
+        // TODO
+    }
+
+    protected void refreshLootcrates() {
+        // TODO
+    }
+}

--- a/common/src/main/java/dev/ftb/mods/ftbxmodcompat/ftbquests/emi/widget/ClickableTextWidget.java
+++ b/common/src/main/java/dev/ftb/mods/ftbxmodcompat/ftbquests/emi/widget/ClickableTextWidget.java
@@ -1,0 +1,24 @@
+package dev.ftb.mods.ftbxmodcompat.ftbquests.emi.widget;
+
+import dev.emi.emi.api.widget.TextWidget;
+import net.minecraft.util.FormattedCharSequence;
+
+import java.util.function.Consumer;
+
+public class ClickableTextWidget extends TextWidget {
+    private final Consumer<ClickableTextWidget> onClick;
+
+    public ClickableTextWidget(FormattedCharSequence text, int x, int y, int color, boolean shadow, Consumer<ClickableTextWidget> onClick) {
+        super(text, x, y, color, shadow);
+        this.onClick = onClick;
+    }
+
+    @Override
+    public boolean mouseClicked(int mouseX, int mouseY, int button) {
+        if (getBounds().contains(mouseX, mouseY)) {
+            onClick.accept(this);
+            return true;
+        }
+        return false;
+    }
+}

--- a/common/src/main/resources/assets/ftbxmodcompat/lang/en_us.json
+++ b/common/src/main/resources/assets/ftbxmodcompat/lang/en_us.json
@@ -1,2 +1,4 @@
 {
+  "emi.category.ftbquests.quest": "Quests",
+  "emi.category.ftbquests.loot_crate": "Loot Crates"
 }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -148,6 +148,7 @@ if (ENV.CURSEFORGE_KEY) {
                 optionalDependency 'kubejs'
                 optionalDependency 'jei'
                 optionalDependency 'roughly-enough-items'
+                optionalDependency 'emi'
                 optionalDependency 'waystones-fabric'
             }
             changelog = ENV.CHANGELOG  // expected to exist if ENV.CURSEFORGE_KEY does

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -19,6 +19,9 @@
     ],
     "rei_client": [
       "dev.ftb.mods.ftbxmodcompat.ftbquests.rei.FTBQuestsREIIntegration"
+    ],
+    "emi": [
+      "dev.ftb.mods.ftbxmodcompat.ftbquests.emi.FTBQuestsEMIIntegration"
     ]
   },
   "depends": {

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -142,6 +142,7 @@ if (ENV.CURSEFORGE_KEY) {
                 optionalDependency 'kubejs'
                 optionalDependency 'jei'
                 optionalDependency 'roughly-enough-items'
+                optionalDependency 'emi'
                 optionalDependency 'game-stages'
                 optionalDependency 'waystones'
             }

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,6 +24,7 @@ kubejs_version=1902.6.1-build.300
 gamestages_version=11.0.2
 rei_version=9.1.619
 jei_version=11.6.0.1016
+emi_version=1.0.19
 common_prot_api_version=1.0.0
 waystones_forge_version=3901921
 waystones_fabric_version=3901920


### PR DESCRIPTION
This PR adds integration with [EMI](https://github.com/emilyploszaj/emi), a new-ish recipe viewer, to FTB Quests. Fixes https://github.com/FTBTeam/FTB-Mods-Issues/issues/312.

TODO:
- [x] Clicking items in the Quest Book UI opens EMI
- [x] Display quest rewards in EMI under a new category
  - [ ] Fix category sometimes not appearing in EMI until after `/reload` - seems to be dependent on mod load order? (which, afaik, is random in Fabric)
  - [ ] Center the quest title text
  - [ ] Maybe use something other than our own `ClickableTextWidget` for opening the quest book from EMI?
- [ ] Display "loot crates" in EMI under a new category

Note: the modpack I'm using for testing is @sisby-folk's [Tinkerer's Quilt](https://modrinth.com/modpack/tinkerers-quilt/version/4.0.1).