### PR TITLE
Add config option to only show "know" waypoints

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftbxmodcompat/config/FTBXModConfig.java
+++ b/common/src/main/java/dev/ftb/mods/ftbxmodcompat/config/FTBXModConfig.java
@@ -17,7 +17,7 @@ public interface FTBXModConfig {
     EnumValue<PermSelector> PERMISSION_SELECTOR = CONFIG.addEnum("permission_selector", NameMap.of(PermSelector.DEFAULT, PermSelector.values()).create())
             .comment("Select the permissions implementation to use", "DEFAULT: use FTB Ranks then Luckperms in preference order, depending on mod availability");
 
-    BooleanValue ONLY_SHOW_KNOW_WAYSTONES = CONFIG.addBoolean("only_show_known_waystones", true)
+    BooleanValue ONLY_SHOW_KNOWN_WAYSTONES = CONFIG.addBoolean("only_show_known_waystones", true)
             .comment("Only show waystones that have been discovered");
 
     enum StageSelector {

--- a/common/src/main/java/dev/ftb/mods/ftbxmodcompat/config/FTBXModConfig.java
+++ b/common/src/main/java/dev/ftb/mods/ftbxmodcompat/config/FTBXModConfig.java
@@ -1,6 +1,7 @@
 package dev.ftb.mods.ftbxmodcompat.config;
 
 import dev.ftb.mods.ftblibrary.config.NameMap;
+import dev.ftb.mods.ftblibrary.snbt.config.BooleanValue;
 import dev.ftb.mods.ftblibrary.snbt.config.EnumValue;
 import dev.ftb.mods.ftblibrary.snbt.config.SNBTConfig;
 import dev.ftb.mods.ftbxmodcompat.FTBXModCompat;
@@ -15,6 +16,9 @@ public interface FTBXModConfig {
 
     EnumValue<PermSelector> PERMISSION_SELECTOR = CONFIG.addEnum("permission_selector", NameMap.of(PermSelector.DEFAULT, PermSelector.values()).create())
             .comment("Select the permissions implementation to use", "DEFAULT: use FTB Ranks then Luckperms in preference order, depending on mod availability");
+
+    BooleanValue ONLY_SHOW_KNOW_WAYSTONES = CONFIG.addBoolean("only_show_known_waystones", true)
+            .comment("Only show waystones that have been discovered");
 
     enum StageSelector {
         DEFAULT(()-> true),

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -73,7 +73,8 @@ processResources {
                 "ftbquestsversion": project.ftb_quests_version,
                 "ftbchunksversion": project.ftb_chunks_version,
                 "ftbranksversion": project.ftb_ranks_version,
-                "ftbteamsversion": project.ftb_teams_version
+                "ftbteamsversion": project.ftb_teams_version,
+                "required_waystones_version": project.required_waystones_version
     }
 }
 

--- a/fabric/src/main/java/dev/ftb/mods/ftbxmodcompat/fabric/ftbchunks/waystones/WaystonesCompat.java
+++ b/fabric/src/main/java/dev/ftb/mods/ftbxmodcompat/fabric/ftbchunks/waystones/WaystonesCompat.java
@@ -1,7 +1,6 @@
 package dev.ftb.mods.ftbxmodcompat.fabric.ftbchunks.waystones;
 
 import com.mojang.logging.LogUtils;
-import dev.ftb.mods.ftbxmodcompat.FTBXModCompat;
 import dev.ftb.mods.ftbxmodcompat.config.FTBXModConfig;
 import dev.ftb.mods.ftbxmodcompat.ftbchunks.waystones.WaystoneData;
 import dev.ftb.mods.ftbxmodcompat.ftbchunks.waystones.WaystoneMapIcon;
@@ -9,9 +8,9 @@ import dev.ftb.mods.ftbxmodcompat.ftbchunks.waystones.WaystonesCommon;
 import net.blay09.mods.balm.api.Balm;
 import net.blay09.mods.waystones.api.Waystone;
 import net.blay09.mods.waystones.api.WaystoneVisibility;
+import net.blay09.mods.waystones.api.WaystonesAPI;
 import net.blay09.mods.waystones.api.event.WaystoneRemoveReceivedEvent;
 import net.blay09.mods.waystones.api.event.WaystoneUpdatedEvent;
-import net.blay09.mods.waystones.core.PlayerWaystoneManager;
 import net.minecraft.client.Minecraft;
 import org.slf4j.Logger;
 
@@ -31,7 +30,7 @@ public class WaystonesCompat {
 	private static void updateWaystone(WaystoneUpdatedEvent event) {
 		LOGGER.trace("waystone updated: {} {}", event.getWaystone().getWaystoneUid(), event.getWaystone().getVisibility());
 		Waystone w = event.getWaystone();
-		if (!FTBXModConfig.ONLY_SHOW_KNOW_WAYSTONES.get() || PlayerWaystoneManager.isWaystoneActivated(Minecraft.getInstance().player, w)) {
+		if (!FTBXModConfig.ONLY_SHOW_KNOW_WAYSTONES.get() || WaystonesAPI.isWaystoneActivated(Minecraft.getInstance().player, w)) {
 			WaystonesCommon.updateWaystone(w.getWaystoneUid(), new WaystoneData(w.getDimension(), new WaystoneMapIcon(w.getPos(), w.getName(), w.getVisibility() == WaystoneVisibility.GLOBAL)));
 		}
 	}

--- a/fabric/src/main/java/dev/ftb/mods/ftbxmodcompat/fabric/ftbchunks/waystones/WaystonesCompat.java
+++ b/fabric/src/main/java/dev/ftb/mods/ftbxmodcompat/fabric/ftbchunks/waystones/WaystonesCompat.java
@@ -30,7 +30,7 @@ public class WaystonesCompat {
 	private static void updateWaystone(WaystoneUpdatedEvent event) {
 		LOGGER.trace("waystone updated: {} {}", event.getWaystone().getWaystoneUid(), event.getWaystone().getVisibility());
 		Waystone w = event.getWaystone();
-		if (!FTBXModConfig.ONLY_SHOW_KNOW_WAYSTONES.get() || WaystonesAPI.isWaystoneActivated(Minecraft.getInstance().player, w)) {
+		if (!FTBXModConfig.ONLY_SHOW_KNOWN_WAYSTONES.get() || WaystonesAPI.isWaystoneActivated(Minecraft.getInstance().player, w)) {
 			WaystonesCommon.updateWaystone(w.getWaystoneUid(), new WaystoneData(w.getDimension(), new WaystoneMapIcon(w.getPos(), w.getName(), w.getVisibility() == WaystoneVisibility.GLOBAL)));
 		}
 	}

--- a/fabric/src/main/java/dev/ftb/mods/ftbxmodcompat/fabric/ftbchunks/waystones/WaystonesCompat.java
+++ b/fabric/src/main/java/dev/ftb/mods/ftbxmodcompat/fabric/ftbchunks/waystones/WaystonesCompat.java
@@ -1,6 +1,8 @@
 package dev.ftb.mods.ftbxmodcompat.fabric.ftbchunks.waystones;
 
+import com.mojang.logging.LogUtils;
 import dev.ftb.mods.ftbxmodcompat.FTBXModCompat;
+import dev.ftb.mods.ftbxmodcompat.config.FTBXModConfig;
 import dev.ftb.mods.ftbxmodcompat.ftbchunks.waystones.WaystoneData;
 import dev.ftb.mods.ftbxmodcompat.ftbchunks.waystones.WaystoneMapIcon;
 import dev.ftb.mods.ftbxmodcompat.ftbchunks.waystones.WaystonesCommon;
@@ -9,21 +11,28 @@ import net.blay09.mods.waystones.api.Waystone;
 import net.blay09.mods.waystones.api.WaystoneVisibility;
 import net.blay09.mods.waystones.api.event.WaystoneRemoveReceivedEvent;
 import net.blay09.mods.waystones.api.event.WaystoneUpdatedEvent;
+import net.blay09.mods.waystones.core.PlayerWaystoneManager;
+import net.minecraft.client.Minecraft;
+import org.slf4j.Logger;
 
 public class WaystonesCompat {
+	private static final Logger LOGGER = LogUtils.getLogger();
+
 	public static void init() {
 		Balm.getEvents().onEvent(WaystoneUpdatedEvent.class, WaystonesCompat::updateWaystone);
 		Balm.getEvents().onEvent(WaystoneRemoveReceivedEvent.class, WaystonesCompat::removeWaystone);
 	}
 
 	private static void removeWaystone(WaystoneRemoveReceivedEvent event) {
-		FTBXModCompat.LOGGER.info("waystone removed: " + event.getWaystoneId());
+		LOGGER.trace("Waystone removed: {}", event.getWaystoneId());
 		WaystonesCommon.removeWaystone(event.getWaystoneId());
 	}
 
 	private static void updateWaystone(WaystoneUpdatedEvent event) {
-		FTBXModCompat.LOGGER.info("waystone updated: " + event.getWaystone().getWaystoneUid());
+		LOGGER.trace("waystone updated: {} {}", event.getWaystone().getWaystoneUid(), event.getWaystone().getVisibility());
 		Waystone w = event.getWaystone();
-		WaystonesCommon.updateWaystone(w.getWaystoneUid(), new WaystoneData(w.getDimension(), new WaystoneMapIcon(w.getPos(), w.getName(), w.getVisibility() == WaystoneVisibility.GLOBAL)));
+		if (!FTBXModConfig.ONLY_SHOW_KNOW_WAYSTONES.get() || PlayerWaystoneManager.isWaystoneActivated(Minecraft.getInstance().player, w)) {
+			WaystonesCommon.updateWaystone(w.getWaystoneUid(), new WaystoneData(w.getDimension(), new WaystoneMapIcon(w.getPos(), w.getName(), w.getVisibility() == WaystoneVisibility.GLOBAL)));
+		}
 	}
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -31,6 +31,7 @@
     "ftbquests": "<2001.3.0",
     "ftbchunks": "<2001.2.0",
     "jei": "<15.2",
-    "kubejs": "<2001.6.3-build.18"
+    "kubejs": "<2001.6.3-build.18",
+    "waystones": "<${required_waystones_version}"
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,14 +31,16 @@ ftb_filter_system_version=21.0.0
 rei_version=16.0.729
 common_prot_api_version=1.0.0
 luckperms_api_version=5.4
-waystones_neoforge_version=5728354
+waystones_neoforge_version=5841748
 waystones_forge_version=5427151
-waystones_fabric_version=5427150
+waystones_fabric_version=5841746
 balm_neoforge_version=5798246
 balm_forge_version=5438000
 balm_fabric_version=5437997
 jei_version=19.21.0.246
 kubejs_version=2100.7.0-build.56
+
+required_waystones_version=21.1.5
 
 # TODO compiling against 1.20.4 version for now
 gamestages_version=15.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ neoforge_version=21.1.13
 neoforge_version_range=[21.1.0,)
 neoforge_loader_version=4
 fabric_loader_version=0.15.11
-fabric_api_version=0.100.1+1.21
+fabric_api_version=0.106.0+1.21.1
 fabric_api_version_range=>=0.100.1+1.21
 
 architectury_version=13.0.6
@@ -31,13 +31,13 @@ ftb_filter_system_version=21.0.0
 rei_version=16.0.729
 common_prot_api_version=1.0.0
 luckperms_api_version=5.4
-waystones_neoforge_version=5427156
+waystones_neoforge_version=5728354
 waystones_forge_version=5427151
 waystones_fabric_version=5427150
-balm_neoforge_version=5438018
+balm_neoforge_version=5798246
 balm_forge_version=5438000
 balm_fabric_version=5437997
-jei_version=19.8.5.118
+jei_version=19.21.0.246
 kubejs_version=2100.7.0-build.56
 
 # TODO compiling against 1.20.4 version for now

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -71,7 +71,8 @@ processResources {
                 "ftbquestsversion": project.ftb_quests_version,
                 "ftbchunksversion": project.ftb_chunks_version,
                 "ftbranksversion": project.ftb_ranks_version,
-                "ftbteamsversion": project.ftb_teams_version
+                "ftbteamsversion": project.ftb_teams_version,
+                "required_waystones_version": project.required_waystones_version
     }
 }
 

--- a/neoforge/src/main/java/dev/ftb/mods/ftbxmodcompat/neoforge/ftbchunks/waystones/WaystonesCompat.java
+++ b/neoforge/src/main/java/dev/ftb/mods/ftbxmodcompat/neoforge/ftbchunks/waystones/WaystonesCompat.java
@@ -1,6 +1,7 @@
 package dev.ftb.mods.ftbxmodcompat.neoforge.ftbchunks.waystones;
 
 import dev.ftb.mods.ftbxmodcompat.FTBXModCompat;
+import dev.ftb.mods.ftbxmodcompat.config.FTBXModConfig;
 import dev.ftb.mods.ftbxmodcompat.ftbchunks.waystones.WaystoneData;
 import dev.ftb.mods.ftbxmodcompat.ftbchunks.waystones.WaystoneMapIcon;
 import dev.ftb.mods.ftbxmodcompat.ftbchunks.waystones.WaystonesCommon;
@@ -8,6 +9,8 @@ import net.blay09.mods.balm.api.Balm;
 import net.blay09.mods.waystones.api.Waystone;
 import net.blay09.mods.waystones.api.WaystoneVisibility;
 import net.blay09.mods.waystones.api.event.*;
+import net.blay09.mods.waystones.core.PlayerWaystoneManager;
+import net.minecraft.client.Minecraft;
 
 public class WaystonesCompat {
 	public static void init() {
@@ -23,6 +26,8 @@ public class WaystonesCompat {
 	private static void updateWaystone(WaystoneUpdatedEvent event) {
 		FTBXModCompat.LOGGER.info("waystone updated: " + event.getWaystone().getWaystoneUid());
 		Waystone w = event.getWaystone();
-		WaystonesCommon.updateWaystone(w.getWaystoneUid(), new WaystoneData(w.getDimension(), new WaystoneMapIcon(w.getPos(), w.getName(), w.getVisibility() == WaystoneVisibility.GLOBAL)));
+		if (!FTBXModConfig.ONLY_SHOW_KNOW_WAYSTONES.get() || PlayerWaystoneManager.isWaystoneActivated(Minecraft.getInstance().player, w)) {
+			WaystonesCommon.updateWaystone(w.getWaystoneUid(), new WaystoneData(w.getDimension(), new WaystoneMapIcon(w.getPos(), w.getName(), w.getVisibility() == WaystoneVisibility.GLOBAL)));
+		}
 	}
 }

--- a/neoforge/src/main/java/dev/ftb/mods/ftbxmodcompat/neoforge/ftbchunks/waystones/WaystonesCompat.java
+++ b/neoforge/src/main/java/dev/ftb/mods/ftbxmodcompat/neoforge/ftbchunks/waystones/WaystonesCompat.java
@@ -1,7 +1,6 @@
 package dev.ftb.mods.ftbxmodcompat.neoforge.ftbchunks.waystones;
 
 import com.mojang.logging.LogUtils;
-import dev.ftb.mods.ftbxmodcompat.FTBXModCompat;
 import dev.ftb.mods.ftbxmodcompat.config.FTBXModConfig;
 import dev.ftb.mods.ftbxmodcompat.ftbchunks.waystones.WaystoneData;
 import dev.ftb.mods.ftbxmodcompat.ftbchunks.waystones.WaystoneMapIcon;
@@ -9,8 +8,8 @@ import dev.ftb.mods.ftbxmodcompat.ftbchunks.waystones.WaystonesCommon;
 import net.blay09.mods.balm.api.Balm;
 import net.blay09.mods.waystones.api.Waystone;
 import net.blay09.mods.waystones.api.WaystoneVisibility;
+import net.blay09.mods.waystones.api.WaystonesAPI;
 import net.blay09.mods.waystones.api.event.*;
-import net.blay09.mods.waystones.core.PlayerWaystoneManager;
 import net.minecraft.client.Minecraft;
 import org.slf4j.Logger;
 
@@ -30,7 +29,7 @@ public class WaystonesCompat {
 	private static void updateWaystone(WaystoneUpdatedEvent event) {
 		LOGGER.trace("waystone updated: {} {}", event.getWaystone().getWaystoneUid(), event.getWaystone().getVisibility());
 		Waystone w = event.getWaystone();
-		if (!FTBXModConfig.ONLY_SHOW_KNOW_WAYSTONES.get() || PlayerWaystoneManager.isWaystoneActivated(Minecraft.getInstance().player, w)) {
+		if (!FTBXModConfig.ONLY_SHOW_KNOW_WAYSTONES.get() || WaystonesAPI.isWaystoneActivated(Minecraft.getInstance().player, w)) {
 			WaystonesCommon.updateWaystone(w.getWaystoneUid(), new WaystoneData(w.getDimension(), new WaystoneMapIcon(w.getPos(), w.getName(), w.getVisibility() == WaystoneVisibility.GLOBAL)));
 		}
 	}

--- a/neoforge/src/main/java/dev/ftb/mods/ftbxmodcompat/neoforge/ftbchunks/waystones/WaystonesCompat.java
+++ b/neoforge/src/main/java/dev/ftb/mods/ftbxmodcompat/neoforge/ftbchunks/waystones/WaystonesCompat.java
@@ -29,7 +29,7 @@ public class WaystonesCompat {
 	private static void updateWaystone(WaystoneUpdatedEvent event) {
 		LOGGER.trace("waystone updated: {} {}", event.getWaystone().getWaystoneUid(), event.getWaystone().getVisibility());
 		Waystone w = event.getWaystone();
-		if (!FTBXModConfig.ONLY_SHOW_KNOW_WAYSTONES.get() || WaystonesAPI.isWaystoneActivated(Minecraft.getInstance().player, w)) {
+		if (!FTBXModConfig.ONLY_SHOW_KNOWN_WAYSTONES.get() || WaystonesAPI.isWaystoneActivated(Minecraft.getInstance().player, w)) {
 			WaystonesCommon.updateWaystone(w.getWaystoneUid(), new WaystoneData(w.getDimension(), new WaystoneMapIcon(w.getPos(), w.getName(), w.getVisibility() == WaystoneVisibility.GLOBAL)));
 		}
 	}

--- a/neoforge/src/main/java/dev/ftb/mods/ftbxmodcompat/neoforge/ftbchunks/waystones/WaystonesCompat.java
+++ b/neoforge/src/main/java/dev/ftb/mods/ftbxmodcompat/neoforge/ftbchunks/waystones/WaystonesCompat.java
@@ -1,5 +1,6 @@
 package dev.ftb.mods.ftbxmodcompat.neoforge.ftbchunks.waystones;
 
+import com.mojang.logging.LogUtils;
 import dev.ftb.mods.ftbxmodcompat.FTBXModCompat;
 import dev.ftb.mods.ftbxmodcompat.config.FTBXModConfig;
 import dev.ftb.mods.ftbxmodcompat.ftbchunks.waystones.WaystoneData;
@@ -11,20 +12,23 @@ import net.blay09.mods.waystones.api.WaystoneVisibility;
 import net.blay09.mods.waystones.api.event.*;
 import net.blay09.mods.waystones.core.PlayerWaystoneManager;
 import net.minecraft.client.Minecraft;
+import org.slf4j.Logger;
 
 public class WaystonesCompat {
+	private static final Logger LOGGER = LogUtils.getLogger();
+
 	public static void init() {
 		Balm.getEvents().onEvent(WaystoneUpdatedEvent.class, WaystonesCompat::updateWaystone);
 		Balm.getEvents().onEvent(WaystoneRemoveReceivedEvent.class, WaystonesCompat::removeWaystone);
 	}
 
 	private static void removeWaystone(WaystoneRemoveReceivedEvent event) {
-		FTBXModCompat.LOGGER.info("waystone removed: " + event.getWaystoneId());
+		LOGGER.trace("Waystone removed: {}", event.getWaystoneId());
 		WaystonesCommon.removeWaystone(event.getWaystoneId());
 	}
 
 	private static void updateWaystone(WaystoneUpdatedEvent event) {
-		FTBXModCompat.LOGGER.info("waystone updated: " + event.getWaystone().getWaystoneUid());
+		LOGGER.trace("waystone updated: {} {}", event.getWaystone().getWaystoneUid(), event.getWaystone().getVisibility());
 		Waystone w = event.getWaystone();
 		if (!FTBXModConfig.ONLY_SHOW_KNOW_WAYSTONES.get() || PlayerWaystoneManager.isWaystoneActivated(Minecraft.getInstance().player, w)) {
 			WaystonesCommon.updateWaystone(w.getWaystoneUid(), new WaystoneData(w.getDimension(), new WaystoneMapIcon(w.getPos(), w.getName(), w.getVisibility() == WaystoneVisibility.GLOBAL)));

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -82,3 +82,8 @@ type = "optional"
 versionRange = "[5.4.112,)"
 ordering = "AFTER"
 side = "SERVER"
+
+[[dependencies.ftbxmodcompat]]
+modId = "waystones"
+type = "optional"
+versionRange = "[${required_waystones_version},)"


### PR DESCRIPTION
Make it so that you can only see "know" waypoints.
This way does use a non API method. Don't what your thoughts about that are about that.
If we should limit our self to pure API methods, we could just use `isOwner` and then just show if someone found it 