### PR TITLE
build: adjust maven repos to not use maven.saps.dev

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,19 +49,23 @@ allprojects {
         }
 
         maven {
-            url "https://maven.saps.dev/releases"
+            url "https://maven.ftb.dev/releases"
             content {
-                includeGroup "dev.latvian.mods"
                 includeGroup "dev.ftb.mods"
-                includeGroup "com.github.llamalad7.mixinextras"
             }
         }
 
         maven {
-            url "https://maven.saps.dev/snapshots"
+            url "https://maven.ftb.dev/snapshots"
+            content {
+                includeGroup "dev.ftb.mods"
+            }
+        }
+
+        maven {
+            url "https://maven.latvian.dev/releases"
             content {
                 includeGroup "dev.latvian.mods"
-                includeGroup "dev.ftb.mods"
             }
         }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,9 +22,9 @@ ftb_ranks_version=2001.1.3
 ftb_essentials_version=2001.2.0
 ftb_teams_version=2001.1.4
 ftb_filter_system_version=1.0.2
-itemfilters_version=2001.1.0-build.55
 
-kubejs_version=2001.6.3-build.18
+itemfilters_version=2001.1.0-build.59
+kubejs_version=2001.6.5-build.19
 gamestages_version=15.0.1
 rei_version=12.0.645
 jei_version=15.2.0.25


### PR DESCRIPTION
Lat mods need to come from maven.latvian.dev - updated KJS and Item Filters dep versions